### PR TITLE
Simplify out of the box plugin usage, fix filename fixtures issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install -D @ds-pack/babel-plugin-docs
 Within your babel config, add the following:
 
 ```js
-plugins: ['@ds-pack/babel-plugin-docs']
+plugins: ['@ds-pack/babel-plugin-docs/plugin']
 ```
 
 ### Tools:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.1",
   "main": "dist/index.js",
   "files": [
-    "dist"
+    "dist",
+    "plugin.js"
   ],
   "repository": "git@github.com:ds-pack/babel-plugin-docs.git",
   "author": "Matt Hamlin <matthewjameshamlin@gmail.com>",

--- a/plugin.js
+++ b/plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/plugin');

--- a/src/__fixtures__/external-prop-types/code.metadata.js
+++ b/src/__fixtures__/external-prop-types/code.metadata.js
@@ -1,6 +1,6 @@
 module.exports = {
   "initialRawCode": "import propType from './external-types'\n\n// Usage:\n// <Foo bar=\"blah\" />\nexport default function Foo() {\n  return <div />\n}\n\nFoo.propTypes = {\n  // some comment here\n  bar: PropTypes.string.isRequired,\n  // another comment here\n  // multi-line this time\n  foo: PropTypes.bool,\n  /**\n   * Block comment here\n   *\n   * With multiple lines\n   */\n  test: propType,\n}\n\nFoo.defaultProps = {\n  bar: 'foo',\n  foo: false,\n  test: 'anotherTest',\n}\n",
-  "filename": "/Users/matt/dev/babel-plugin-docs/src/__fixtures__/external-prop-types/code.js",
+  "filename": "<project-root>/__fixtures__/external-prop-types/code.js",
   "components": [
     {
       "name": "Foo",

--- a/src/__fixtures__/prop-types/code.metadata.js
+++ b/src/__fixtures__/prop-types/code.metadata.js
@@ -1,6 +1,6 @@
 module.exports = {
   "initialRawCode": "// Usage:\n// <Foo bar=\"blah\" />\nexport default function Foo() {\n  return <div />\n}\n\nlet test\n\nFoo.propTypes = {\n  // some comment here\n  bar: PropTypes.string.isRequired,\n  // another comment here\n  // multi-line this time\n  foo: PropTypes.bool,\n  /**\n   * Block comment here\n   *\n   * With multiple lines\n   */\n  test,\n}\n\nFoo.defaultProps = {\n  bar: 'foo',\n  foo: false,\n  test: 'anotherTest',\n}\n",
-  "filename": "/Users/matt/dev/babel-plugin-docs/src/__fixtures__/prop-types/code.js",
+  "filename": "<project-root>/__fixtures__/prop-types/code.js",
   "components": [
     {
       "name": "Foo",

--- a/src/__fixtures__/static-prop-types-component-alias-import/code.metadata.js
+++ b/src/__fixtures__/static-prop-types-component-alias-import/code.metadata.js
@@ -1,6 +1,6 @@
 module.exports = {
   "initialRawCode": "import { Component as Comp } from 'react'\n\nexport default class Foo extends Comp {\n  static propTypes = {\n    // Some comment here\n    bar: PropTypes.string,\n  }\n\n  static defaultProps = {\n    bar: 'foo',\n  }\n\n  static _propTypes = 'something internal'\n\n  render() {\n    return null\n  }\n}\n",
-  "filename": "/Users/matt/dev/babel-plugin-docs/src/__fixtures__/static-prop-types-component-alias-import/code.js",
+  "filename": "<project-root>/__fixtures__/static-prop-types-component-alias-import/code.js",
   "components": [
     {
       "name": "Foo",

--- a/src/__fixtures__/static-prop-types-react-default-import/code.metadata.js
+++ b/src/__fixtures__/static-prop-types-react-default-import/code.metadata.js
@@ -1,6 +1,6 @@
 module.exports = {
   "initialRawCode": "import React from 'react'\n\nexport default class Foo extends React.Component {\n  static propTypes = {\n    // Some comment here\n    bar: PropTypes.string,\n  }\n\n  static defaultProps = {\n    bar: 'foo',\n  }\n\n  static _propTypes = 'something internal'\n\n  render() {\n    return null\n  }\n}\n",
-  "filename": "/Users/matt/dev/babel-plugin-docs/src/__fixtures__/static-prop-types-react-default-import/code.js",
+  "filename": "<project-root>/__fixtures__/static-prop-types-react-default-import/code.js",
   "components": [
     {
       "name": "Foo",

--- a/src/__fixtures__/static-prop-types-react-namespace-import/code.metadata.js
+++ b/src/__fixtures__/static-prop-types-react-namespace-import/code.metadata.js
@@ -1,6 +1,6 @@
 module.exports = {
   "initialRawCode": "import * as react from 'react'\n\nexport default class Foo extends react.Component {\n  static propTypes = {\n    // Some comment here\n    bar: PropTypes.string,\n  }\n\n  static defaultProps = {\n    bar: 'foo',\n  }\n\n  static _propTypes = 'something internal'\n\n  render() {\n    return null\n  }\n}\n",
-  "filename": "/Users/matt/dev/babel-plugin-docs/src/__fixtures__/static-prop-types-react-namespace-import/code.js",
+  "filename": "<project-root>/__fixtures__/static-prop-types-react-namespace-import/code.js",
   "components": [
     {
       "name": "Foo",

--- a/src/__fixtures__/supports-documenting-hocs-class/code.metadata.js
+++ b/src/__fixtures__/supports-documenting-hocs-class/code.metadata.js
@@ -1,6 +1,6 @@
 module.exports = {
   "initialRawCode": "// Usage:\n// <Foo bar=\"blah\" />\nexport default function makeFoo(Comp) {\n  let test\n\n  return class Foo extends React.Component {\n    static propTypes = {\n      // some comment here\n      bar: PropTypes.string.isRequired,\n      // another comment here\n      // multi-line this time\n      foo: PropTypes.bool,\n      /**\n       * Block comment here\n       *\n       * With multiple lines\n       */\n      test,\n    }\n\n    static defaultProps = {\n      bar: 'foo',\n      foo: false,\n      test: 'anotherTest',\n    }\n\n    render() {\n      return <div />\n    }\n  }\n}\n",
-  "filename": "/Users/matt/dev/babel-plugin-docs/src/__fixtures__/supports-documenting-hocs-class/code.js",
+  "filename": "<project-root>/__fixtures__/supports-documenting-hocs-class/code.js",
   "components": [],
   "imports": [],
   "hooks": []

--- a/src/__fixtures__/supports-documenting-hocs-function/code.metadata.js
+++ b/src/__fixtures__/supports-documenting-hocs-function/code.metadata.js
@@ -1,6 +1,6 @@
 module.exports = {
   "initialRawCode": "// Usage:\n// <Foo bar=\"blah\" />\nexport default function makeFoo(Comp) {\n  function Foo(props) {\n    return <div />\n  }\n\n  let test\n\n  Foo.propTypes = {\n    // some comment here\n    bar: PropTypes.string.isRequired,\n    // another comment here\n    // multi-line this time\n    foo: PropTypes.bool,\n    /**\n     * Block comment here\n     *\n     * With multiple lines\n     */\n    test,\n  }\n\n  Foo.defaultProps = {\n    bar: 'foo',\n    foo: false,\n    test: 'anotherTest',\n  }\n\n  return Foo\n}\n",
-  "filename": "/Users/matt/dev/babel-plugin-docs/src/__fixtures__/supports-documenting-hocs-function/code.js",
+  "filename": "<project-root>/__fixtures__/supports-documenting-hocs-function/code.js",
   "components": [
     {
       "name": "Foo",

--- a/src/__fixtures__/supports-documenting-hooks-basic/code.metadata.js
+++ b/src/__fixtures__/supports-documenting-hooks-basic/code.metadata.js
@@ -1,6 +1,6 @@
 module.exports = {
   "initialRawCode": "/**\n * useFoo\n *\n * Example Usage:\n * ```jsx\n * const val = useFoo(initialState);\n * ```\n *\n * @param {number} initialState The initial state of the useFoo hook\n * @returns {number} The current value\n */\nexport default function useFoo() {\n  return []\n}\n",
-  "filename": "/Users/matt/dev/babel-plugin-docs/src/__fixtures__/supports-documenting-hooks-basic/code.js",
+  "filename": "<project-root>/__fixtures__/supports-documenting-hooks-basic/code.js",
   "components": [],
   "imports": [],
   "hooks": [

--- a/src/__fixtures__/works/code.metadata.js
+++ b/src/__fixtures__/works/code.metadata.js
@@ -1,6 +1,6 @@
 module.exports = {
   "initialRawCode": "// Usage:\n// <Foo bar=\"blah\" />\nexport default function Foo() {\n  return <div />\n}\n\nFoo.propTypes = {\n  // some comment here\n  bar: PropTypes.string.isRequired,\n}\n",
-  "filename": "/Users/matt/dev/babel-plugin-docs/src/__fixtures__/works/code.js",
+  "filename": "<project-root>/__fixtures__/works/code.js",
   "components": [
     {
       "name": "Foo",

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,1 @@
-export { docsPlugin as plugin } from './plugin'
+export { default as plugin } from './plugin'

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -67,7 +67,7 @@ function lookupLocalOrImportedReferences({
   }
 }
 
-export function docsPlugin({ types }) {
+export default function docsPlugin({ types }) {
   let data = {
     initialRawCode: '',
     filename: '',
@@ -89,7 +89,8 @@ export function docsPlugin({ types }) {
     inherits: require('babel-plugin-syntax-jsx'),
     pre(state) {
       data.initialRawCode = state.code
-      data.filename = state.opts.filename
+      let directoryName = state.opts.dirname || __dirname;
+      data.filename = state.opts.filename.replace(directoryName, '<project-root>')
     },
     visitor: {
       ImportDeclaration: createImportDeclaration({ types, data }),


### PR DESCRIPTION
Changes:

* Update docs for consumption of plugin
* Have `plugin` entrypoint export default the plugin
* Update filename key in metadata output to replace the project root (stable fixtures runs)